### PR TITLE
[CMS-319] simplify code, faster read

### DIFF
--- a/backend/functions/public_api/db.py
+++ b/backend/functions/public_api/db.py
@@ -27,6 +27,14 @@ class DataSource(BaseModel):
         table_name = "projects_datasource"
 
 
+class DataSourceMeta(BaseModel):
+    datasource = ForeignKeyField(DataSource, backref="meta_data")
+    items = IntegerField()
+
+    class Meta:
+        table_name = "projects_datasourcemeta"
+
+
 class Job(BaseModel):
     datasource = ForeignKeyField(DataSource, backref="jobs")
     result = CharField()

--- a/backend/functions/worker/handler.py
+++ b/backend/functions/worker/handler.py
@@ -20,7 +20,7 @@ db.initialize()
 def write_dataframe_to_csv_on_s3(dataframe, filename):
     csv_buffer = StringIO()
 
-    dataframe.to_csv(csv_buffer, index=False)
+    dataframe.to_csv(csv_buffer, encoding="utf-8", index=False)
 
     return services.s3_resource.Object(
         settings.AWS_STORAGE_BUCKET_NAME, filename


### PR DESCRIPTION
Ok, so I did some research and test, so there is my conclusion:

- `datatable` is fast and doesn't use lots of memory to read whole file but we have to do it every time, so for example when I was testing locally get one page of results from ~150mb csv took around 2,4-2,8 sek, no matter if is page nr 1 or 1000, extra pros: we have full data available so we don't need extra query to db to get csv items count

- `pandas` I tested `read_csv` method with `iterator=True` and `skiprows=`, that creates lazy object that I can iterate over to get rows, so we don't loading full csv every time and because of that fetching pages is much faster, for example to fetch first page I need around 0.012 sek. But every next page needs more time because there is more rows to skip, so to load page 1000 pandas  needed around 2,7-3,1 sek, what is similar to datatable time and I didn't notice any big jumps of memory on my local machine, extra disadvantage: we need extra db query to get `items` count from `datasource.meta_data`

So I think we should try this second approach, because is much faster and code is simpler.
I added encoding to `to_csv` method in worker lambda, so every result file will be saved using 'utf-8' so there shouldn't be problems with reading results using pandas in `public api lambda`.