### PR TITLE
CMS-488 Update data source after revert job

### DIFF
--- a/frontend/schemaCMS/src/modules/dataSource/__tests__/dataSource.sagas.spec.js
+++ b/frontend/schemaCMS/src/modules/dataSource/__tests__/dataSource.sagas.spec.js
@@ -249,12 +249,15 @@ describe('DataSource: sagas', () => {
   describe('revertToJob', () => {
     it('should dispatch a success action', async () => {
       const payload = { jobId: '1', dataSourceId: '1' };
+      const response = { id: '1' };
 
-      mockApi.post(`${DATA_SOURCES_PATH}/${payload.dataSourceId}/revert-job`, { id: payload.jobId }).reply(OK);
+      mockApi
+        .post(`${DATA_SOURCES_PATH}/${payload.dataSourceId}/revert-job`, { id: payload.jobId })
+        .reply(OK, response);
 
       await expectSaga(watchDataSource)
         .withState(defaultState)
-        .put(DataSourceRoutines.revertToJob.success())
+        .put(DataSourceRoutines.revertToJob.success(response))
         .dispatch(DataSourceRoutines.revertToJob(payload))
         .silentRun();
     });

--- a/frontend/schemaCMS/src/modules/dataSource/dataSource.redux.js
+++ b/frontend/schemaCMS/src/modules/dataSource/dataSource.redux.js
@@ -41,4 +41,5 @@ export const reducer = createReducer(INITIAL_STATE, {
   [DataSourceRoutines.fetchList.SUCCESS]: updateDataSources,
   [DataSourceRoutines.fetchFieldsInfo.SUCCESS]: setFieldsInfo,
   [DataSourceRoutines.fetchPreview.SUCCESS]: setPreviewData,
+  [DataSourceRoutines.revertToJob.SUCCESS]: updateDataSource,
 });

--- a/frontend/schemaCMS/src/modules/dataSource/dataSource.sagas.js
+++ b/frontend/schemaCMS/src/modules/dataSource/dataSource.sagas.js
@@ -160,9 +160,9 @@ function* revertToJob({ payload: { dataSourceId, jobId } }) {
   try {
     yield put(DataSourceRoutines.revertToJob.request());
 
-    yield api.post(`${DATA_SOURCES_PATH}/${dataSourceId}/revert-job`, { id: jobId });
+    const { data } = yield api.post(`${DATA_SOURCES_PATH}/${dataSourceId}/revert-job`, { id: jobId });
 
-    yield put(DataSourceRoutines.revertToJob.success());
+    yield put(DataSourceRoutines.revertToJob.success(data));
     browserHistory.push(`/datasource/${dataSourceId}/4`);
   } catch (error) {
     yield put(DataSourceRoutines.revertToJob.failure(error));


### PR DESCRIPTION
Hold with merge until backend will send us in response of revert job a datasource.